### PR TITLE
add:rails generate設定追加/gem Rubocopを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,8 @@ group :development, :test do
 
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false
+  gem "rubocop"
+  gem "rubocop-rails"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -301,6 +301,8 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.2, >= 7.2.2.1)
+  rubocop
+  rubocop-rails
   rubocop-rails-omakase
   selenium-webdriver
   sprockets-rails

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,10 @@ module Myapp
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    config.generators do |g|
+      g.skip_routes true
+      g.helper false
+      g.test_framework nil
+    end
   end
 end


### PR DESCRIPTION
概要
rails generateコマンドによる作成ファイルの設定、およびLintチェックのためにgem rubcopを導入しました。

- [x] add:rails gコマンド作成ファイル設定
- [x] add:gem rubocop追加