### PR TITLE
deploy_3:中間デプロイ(2)

### DIFF
--- a/db/migrate/20250309004755_add_name_to_users.rb
+++ b/db/migrate/20250309004755_add_name_to_users.rb
@@ -1,5 +1,0 @@
-class AddNameToUsers < ActiveRecord::Migration[7.2]
-  def change
-    add_column :users, :name, :string, null: false
-  end
-end


### PR DESCRIPTION
**概要**
Herokuでdb:migrateしたところ、AddNameToUsersマイグレーションファイルがすでに適用済みのため、エラーが発生してしまった。マイグレーションファイルを削除。